### PR TITLE
Removed outdated info

### DIFF
--- a/src/projects/stae401g/index.rst
+++ b/src/projects/stae401g/index.rst
@@ -8,7 +8,6 @@ Stærðfræðigreining IV (STÆ401G), Háskóli Íslands
 
 .. toctree::
 	formali
-	umnamskeidid
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Made it so that a "about this course" page was not added in Edbook, as it was outdated, but left the file itself was there if a future teacher wanted to use it.